### PR TITLE
make api for timetable reorder

### DIFF
--- a/src/common/interfaces/dto/timetable/timetable.request.dto.ts
+++ b/src/common/interfaces/dto/timetable/timetable.request.dto.ts
@@ -53,3 +53,9 @@ export class AddLectureDto {
   @Type(() => Number)
   lecture!: number;
 }
+
+export class ReorderTimetableDto {
+  @IsNumber()
+  @Type(() => Number)
+  arrange_order!: number;
+}

--- a/src/modules/timetables/timetables.controller.ts
+++ b/src/modules/timetables/timetables.controller.ts
@@ -11,6 +11,7 @@ import { session_userprofile } from '@prisma/client';
 import { GetUser } from '../../common/decorators/get-user.decorator';
 import {
   AddLectureDto,
+  ReorderTimetableDto,
   TimetableCreateDto,
   TimetableQueryDto,
 } from '../../common/interfaces/dto/timetable/timetable.request.dto';
@@ -88,6 +89,24 @@ export class TimetablesController {
     @Body() body: AddLectureDto,
   ) {
     const timeTable = await this.timetablesService.removeLectureFromTimetable(
+      timetableId,
+      body,
+    );
+    return toJsonTimetable(timeTable);
+  }
+
+  @Post('/:timetableId/reorder')
+  async reorderTimetable(
+    @Param('userId') userId: number,
+    @Param('timetableId') timetableId: number,
+    @Body() body: ReorderTimetableDto,
+    @GetUser() user: session_userprofile,
+  ) {
+    // TODO: use user by auth instead of userId by endpoint param
+    // userId should be removed from endpoint in the future
+    // since each user should only control their own timetable
+    const timeTable = await this.timetablesService.reorderTimetable(
+      user,
       timetableId,
       body,
     );

--- a/src/modules/timetables/timetables.controller.ts
+++ b/src/modules/timetables/timetables.controller.ts
@@ -97,14 +97,16 @@ export class TimetablesController {
 
   @Post('/:timetableId/reorder')
   async reorderTimetable(
+    /**
+     * @todo use user by auth instead of userId by endpoint param
+     * userId should be removed from endpoint in the future
+     * since each user should only control their own timetable
+     */
     @Param('userId') userId: number,
     @Param('timetableId') timetableId: number,
     @Body() body: ReorderTimetableDto,
     @GetUser() user: session_userprofile,
   ) {
-    // TODO: use user by auth instead of userId by endpoint param
-    // userId should be removed from endpoint in the future
-    // since each user should only control their own timetable
     const timeTable = await this.timetablesService.reorderTimetable(
       user,
       timetableId,

--- a/src/modules/timetables/timetables.service.ts
+++ b/src/modules/timetables/timetables.service.ts
@@ -194,6 +194,7 @@ export class TimetablesService {
       if (targetArrangeOrder === targetTimetable.arrange_order) {
         return targetTimetable;
       }
+
       const relatedTimeTables = await this.timetableRepository.getTimetables(
         user,
         targetTimetable.year,
@@ -205,6 +206,7 @@ export class TimetablesService {
       ) {
         throw new BadRequestException('Wrong field arrange_order in request');
       }
+
       let timeTablesToBeUpdated: { id: number; arrange_order: number }[] = [];
       if (targetArrangeOrder < targetTimetable.arrange_order) {
         timeTablesToBeUpdated = relatedTimeTables
@@ -233,6 +235,7 @@ export class TimetablesService {
             };
           });
       }
+
       await Promise.all(
         timeTablesToBeUpdated.map(async (timetable) => {
           return this.timetableRepository.updateOrder(

--- a/src/modules/timetables/timetables.service.ts
+++ b/src/modules/timetables/timetables.service.ts
@@ -1,11 +1,8 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { session_userprofile } from '@prisma/client';
 import {
   AddLectureDto,
+  ReorderTimetableDto,
   TimetableCreateDto,
   TimetableQueryDto,
 } from '../../common/interfaces/dto/timetable/timetable.request.dto';
@@ -179,6 +176,75 @@ export class TimetablesService {
           );
         }),
       );
+    });
+  }
+
+  async reorderTimetable(
+    user: session_userprofile,
+    timetableId: number,
+    body: ReorderTimetableDto,
+  ) {
+    return await this.prismaService.$transaction(async (tx) => {
+      const { arrange_order: targetArrangeOrder } = body;
+      const targetTimetable = await this.getTimetable(timetableId);
+      if (targetTimetable.user_id !== user.id) {
+        throw new BadRequestException('User is not owner of timetable');
+      }
+      const relatedTimeTables = await this.timetableRepository.getTimetables(
+        user,
+        targetTimetable.year,
+        targetTimetable.semester,
+      );
+      if (
+        targetArrangeOrder < 0 ||
+        targetArrangeOrder >= relatedTimeTables.length
+      ) {
+        throw new BadRequestException('Wrong field arrange_order in request');
+      }
+      let timeTablesToBeUpdated: { id: number; arrange_order: number }[] = [];
+      if (targetArrangeOrder < targetTimetable.arrange_order) {
+        timeTablesToBeUpdated = relatedTimeTables
+          .filter(
+            (timeTable) =>
+              timeTable.arrange_order >= targetArrangeOrder &&
+              timeTable.arrange_order < targetTimetable.arrange_order,
+          )
+          .map((timeTable) => {
+            return {
+              id: timeTable.id,
+              arrange_order: timeTable.arrange_order + 1,
+            };
+          });
+      } else if (targetArrangeOrder > targetTimetable.arrange_order) {
+        timeTablesToBeUpdated = relatedTimeTables
+          .filter(
+            (timeTable) =>
+              timeTable.arrange_order <= targetArrangeOrder &&
+              timeTable.arrange_order > targetTimetable.arrange_order,
+          )
+          .map((timeTable) => {
+            return {
+              id: timeTable.id,
+              arrange_order: timeTable.arrange_order - 1,
+            };
+          });
+      } else {
+        // arrange_order == timetable.arrange_order
+        return await this.timetableRepository.getTimeTableById(timetableId);
+      }
+      await Promise.all(
+        timeTablesToBeUpdated.map(async (timetable) => {
+          return this.timetableRepository.updateOrder(
+            timetable.id,
+            timetable.arrange_order,
+          );
+        }),
+      );
+      await this.timetableRepository.updateOrder(
+        targetTimetable.id,
+        targetArrangeOrder,
+      );
+      return await this.timetableRepository.getTimeTableById(timetableId);
     });
   }
 }


### PR DESCRIPTION
[django](https://github.com/sparcs-kaist/otlplus/blob/01a825962f9009fbe6f2d43d1f90e88f351f1b02/apps/timetable/views.py#L181) 코드 거의 그대로 옮겼습니다.
에러 처리만 조금 더 신경썼습니다.

현재 prisma transaction이 제대로 이루어지지 않은 상태이나, 이 부분은 명확한 solution이 정리된 이후 다른 API와 묶어 한 번에 refactoring하는 것이 맞아보입니다.
arrange_order 관련 정합성 문제가 있습니다.