### PR TITLE
chore: add prisma-generate on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, release]
+    branches: [main, dev, release, ci/*]
   pull_request:
-    branches: [main, dev, release]
+    branches: [main, dev, release, ci/*]
 
 env:
   NODE_VERSION: 18
@@ -60,5 +60,7 @@ jobs:
         run: npm ci
       - name: Copy env file
         run: cp ./env/.env.example ./env/.env.local
+      - name: Generate prisma
+        run: prisma-generate
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: npm ci
       - name: Copy env file
         run: cp ./env/.env.example ./env/.env.local
-      - name: Generate prisma
+      - name: Generate PrismaClient
         run: npm run prisma-generate
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Copy env file
         run: cp ./env/.env.example ./env/.env.local
       - name: Generate prisma
-        run: prisma-generate
+        run: npm run prisma-generate
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, release, ci/*]
+    branches: [main, dev, release]
   pull_request:
-    branches: [main, dev, release, ci/*]
+    branches: [main, dev, release]
 
 env:
   NODE_VERSION: 18


### PR DESCRIPTION
1. build를 할 때 prisma-client를 만들기 위해서는 `prisma-generate` 가 필요합니다. CI 에서 prebuild step으로 generating을 추가합니다.
2. ~~ci target branch에 `ci/*` 를 추가해서, ci 관련 작업은 해당 브랜치에서 작업합니다.~~ (target branch만 dev면 된다)