### PR TITLE
refactor: remove request, query logs

### DIFF
--- a/src/bootstrap/bootstrap.ts
+++ b/src/bootstrap/bootstrap.ts
@@ -37,17 +37,17 @@ async function bootstrap() {
   );
   app.use(cookieParser());
   // Logs requests
-  app.use(
-    morgan(':method :url OS/:req[client-os] Ver/:req[client-api-version]', {
-      // https://github.com/expressjs/morgan#immediate
-      immediate: true,
-      stream: {
-        write: (message) => {
-          console.info(message.trim());
-        },
-      },
-    }),
-  );
+  // app.use(
+  //   morgan(':method :url OS/:req[client-os] Ver/:req[client-api-version]', {
+  //     // https://github.com/expressjs/morgan#immediate
+  //     immediate: true,
+  //     stream: {
+  //       write: (message) => {
+  //         console.info(message.trim());
+  //       },
+  //     },
+  //   }),
+  // );
 
   // Logs responses
   app.use(

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -14,7 +14,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
     // @ts-ignore
     this.$on('query', async (e) => {
       // @ts-ignore
-      console.log(`Query: ${e.query} ${e.params}`);
+      // console.log(`Query: ${e.query} ${e.params}`);
     });
   }
 


### PR DESCRIPTION
콘솔에 log가 너무 많이 남아서 response log만 남겨두고 request, query log를 제거합니다.