### PR TITLE
refactor: repository dependency injection

### DIFF
--- a/src/modules/feeds/feeds.service.ts
+++ b/src/modules/feeds/feeds.service.ts
@@ -20,6 +20,23 @@ export class FeedsService {
     }
   }
 
+  private async getFamousHumanityReview(
+    date: Date,
+  ): Promise<EFeed.FamousHumanityReviewDetails> {
+    let feed = await this.feedsRepository.getFamousHumanityReview(date);
+    if (!feed) {
+      const humanityBestReviews =
+        await this.reviewsRepository.getTopNHumanityBestReviews(3);
+
+      feed = await this.feedsRepository.createFamousHumanityReview(
+        date,
+        humanityBestReviews,
+      );
+    }
+
+    return feed;
+  }
+
   public async getFeeds(query: IFeed.QueryDto, user: session_userprofile) {
     const { date: dateString } = query;
     const date = new Date(dateString);
@@ -28,8 +45,7 @@ export class FeedsService {
     );
     const feeds: EFeed.Details[] = [];
 
-    const famousHumanityReview =
-      await this.feedsRepository.getOrCreateFamousHumanityReview(date);
+    const famousHumanityReview = await this.getFamousHumanityReview(date);
     this.filterFeeds(feeds, famousHumanityReview);
 
     /**

--- a/src/modules/feeds/feeds.service.ts
+++ b/src/modules/feeds/feeds.service.ts
@@ -20,9 +20,7 @@ export class FeedsService {
     }
   }
 
-  private async getFamousHumanityReview(
-    date: Date,
-  ): Promise<EFeed.FamousHumanityReviewDetails> {
+  private async getFamousHumanityReview(date: Date) {
     let feed = await this.feedsRepository.getFamousHumanityReview(date);
     if (!feed) {
       const humanityBestReviews =
@@ -34,6 +32,15 @@ export class FeedsService {
       );
     }
 
+    return feed;
+  }
+
+  private async getRankedReview(date: Date) {
+    let feed = await this.feedsRepository.getRankedReview(date);
+
+    if (!feed) {
+      feed = await this.feedsRepository.createRankedReview(date);
+    }
     return feed;
   }
 
@@ -52,9 +59,7 @@ export class FeedsService {
      * "RANKED_REVIEW" does not require RankedReview
      * Always shows TOP 3 liked reviews.
      */
-    const rankedReview = await this.feedsRepository.getOrCreateRankedReview(
-      date,
-    );
+    const rankedReview = await this.getRankedReview(date);
     const top3LikedReviews = await this.reviewsRepository.getTopLikedReviews(3);
 
     /**

--- a/src/modules/feeds/feeds.service.ts
+++ b/src/modules/feeds/feeds.service.ts
@@ -99,6 +99,28 @@ export class FeedsService {
     return feed;
   }
 
+  private async getRelatedCourses(date: Date, userId: number) {
+    let feed = await this.feedsRepository.getRelatedCourse(date, userId);
+
+    if (!feed) {
+      const takenLecture = getRandomChoice(
+        await this.userRepository.getTakenLectures(userId),
+      );
+
+      if (!takenLecture) {
+        return null;
+      }
+
+      feed = await this.feedsRepository.createRelatedCourse(
+        date,
+        userId,
+        takenLecture.lecture.course_id,
+      );
+    }
+
+    return feed;
+  }
+
   public async getFeeds(query: IFeed.QueryDto, user: session_userprofile) {
     const { date: dateString } = query;
     const date = new Date(dateString);
@@ -143,10 +165,7 @@ export class FeedsService {
      * RelatedCourse does not have Datas of posterior or prior courses.
      * Comment out below until having enough Datas.
      */
-    // const relatedCourse = await this.feedsRepository.getOrCreateRelatedCourse(
-    //   date,
-    //   user.id,
-    // );
+    // const relatedCourse = await this.getRelatedCourses(date, user.id);
     // this.filterFeeds(feeds, relatedCourse);
 
     const rateDaily = await this.feedsRepository.getOrCreateRate(date, user.id);

--- a/src/modules/feeds/feeds.service.ts
+++ b/src/modules/feeds/feeds.service.ts
@@ -6,6 +6,7 @@ import { getRandomChoice } from 'src/common/utils/method.utils';
 import { DepartmentRepository } from 'src/prisma/repositories/department.repository';
 import { FeedsRepository } from 'src/prisma/repositories/feeds.repository';
 import { ReviewsRepository } from 'src/prisma/repositories/review.repository';
+import { SemesterRepository } from 'src/prisma/repositories/semester.repository';
 import { UserRepository } from 'src/prisma/repositories/user.repository';
 
 @Injectable()
@@ -15,6 +16,7 @@ export class FeedsService {
     private readonly feedsRepository: FeedsRepository,
     private readonly reviewsRepository: ReviewsRepository,
     private readonly userRepository: UserRepository,
+    private readonly semesterRepository: SemesterRepository,
   ) {}
 
   private filterFeeds(feeds: EFeed.Details[], feed: EFeed.Details | null) {
@@ -81,8 +83,10 @@ export class FeedsService {
     let feed = await this.feedsRepository.getReviewWrite(date, userId);
 
     if (!feed) {
+      const notWritableSemester =
+        await this.semesterRepository.getNotWritableSemester();
       const takenLecture = getRandomChoice(
-        await this.userRepository.getReviewWritableTakenLectures(userId),
+        await this.userRepository.getTakenLectures(userId, notWritableSemester),
       );
 
       feed = await this.feedsRepository.createReviewWrite(

--- a/src/prisma/repositories/feeds.repository.ts
+++ b/src/prisma/repositories/feeds.repository.ts
@@ -23,37 +23,32 @@ export class FeedsRepository {
     private readonly userRepository: UserRepository,
   ) {}
 
-  public async getOrCreateFamousHumanityReview(date: Date) {
-    let feed = await this.prisma.main_famoushumanityreviewdailyfeed.findFirst({
+  public async getFamousHumanityReview(date: Date) {
+    return await this.prisma.main_famoushumanityreviewdailyfeed.findFirst({
       where: {
         date,
       },
       include: EFeed.FamousHumanityReviewDetails.include,
     });
+  }
 
-    if (!feed) {
-      // Prisma does not support RAND() in ORDER BY.
-      const humanityBestReviews = (await this.prisma.$queryRaw`
-        SELECT * FROM review_humanitybestreview 
-        ORDER BY RAND() 
-        LIMIT 3`) satisfies review_humanitybestreview;
-
-      feed = await this.prisma.main_famoushumanityreviewdailyfeed.create({
-        include: EFeed.FamousHumanityReviewDetails.include,
-        data: {
-          date,
-          priority: Math.random(),
-          main_famoushumanityreviewdailyfeed_reviews: {
-            createMany: {
-              data: humanityBestReviews,
-            },
+  public async createFamousHumanityReview(
+    date: Date,
+    humanityBestReviews: review_humanitybestreview,
+  ) {
+    return await this.prisma.main_famoushumanityreviewdailyfeed.create({
+      include: EFeed.FamousHumanityReviewDetails.include,
+      data: {
+        date,
+        priority: Math.random(),
+        main_famoushumanityreviewdailyfeed_reviews: {
+          createMany: {
+            data: humanityBestReviews,
           },
-          visible: Math.random() < FeedVisibleRate.FamousHumanityReview,
         },
-      });
-    }
-
-    return feed;
+        visible: Math.random() < FeedVisibleRate.FamousHumanityReview,
+      },
+    });
   }
 
   public async getOrCreateRankedReview(date: Date) {

--- a/src/prisma/repositories/feeds.repository.ts
+++ b/src/prisma/repositories/feeds.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import {
   main_ratedailyuserfeed,
   main_relatedcoursedailyuserfeed,
-  main_reviewwritedailyuserfeed,
   review_humanitybestreview,
   review_majorbestreview,
   subject_department,
@@ -130,42 +129,6 @@ export class FeedsRepository {
       },
     });
   }
-
-  public async getOrCreateReviewWrite(
-    date: Date,
-    userId: number,
-  ): Promise<main_reviewwritedailyuserfeed | null> {
-    let feed = await this.prisma.main_reviewwritedailyuserfeed.findFirst({
-      include: EFeed.ReviewWriteDetails.include,
-      where: {
-        date,
-        user_id: userId,
-      },
-    });
-
-    if (!feed) {
-      const takenLecture = getRandomChoice(
-        await this.userRepository.getReviewWritableTakenLectures(userId),
-      );
-      if (!takenLecture) {
-        return null;
-      }
-
-      feed = await this.prisma.main_reviewwritedailyuserfeed.create({
-        include: EFeed.ReviewWriteDetails.include,
-        data: {
-          date,
-          priority: Math.random(),
-          visible: Math.random() < FeedVisibleRate.ReviewWrite,
-          user_id: userId,
-          lecture_id: takenLecture.lecture_id,
-        },
-      });
-    }
-
-    return feed;
-  }
-
   public async getOrCreateRelatedCourse(
     date: Date,
     userId: number,

--- a/src/prisma/repositories/feeds.repository.ts
+++ b/src/prisma/repositories/feeds.repository.ts
@@ -51,24 +51,22 @@ export class FeedsRepository {
     });
   }
 
-  public async getOrCreateRankedReview(date: Date) {
-    let feed = await this.prisma.main_rankedreviewdailyfeed.findFirst({
+  public async getRankedReview(date: Date) {
+    return await this.prisma.main_rankedreviewdailyfeed.findFirst({
       where: {
         date,
       },
     });
+  }
 
-    if (!feed) {
-      feed = await this.prisma.main_rankedreviewdailyfeed.create({
-        data: {
-          date,
-          priority: Math.random(),
-          visible: Math.random() < FeedVisibleRate.RankedReview,
-        },
-      });
-    }
-
-    return feed;
+  public async createRankedReview(date: Date) {
+    return await this.prisma.main_rankedreviewdailyfeed.create({
+      data: {
+        date,
+        priority: Math.random(),
+        visible: Math.random() < FeedVisibleRate.RankedReview,
+      },
+    });
   }
 
   public async getOrCreateFamousMajorReview(

--- a/src/prisma/repositories/feeds.repository.ts
+++ b/src/prisma/repositories/feeds.repository.ts
@@ -11,14 +11,10 @@ import {
   FeedVisibleRate,
 } from 'src/common/interfaces/constants/feed';
 import { PrismaService } from '../prisma.service';
-import { UserRepository } from './user.repository';
 
 @Injectable()
 export class FeedsRepository {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly userRepository: UserRepository,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   public async getFamousHumanityReview(date: Date) {
     return await this.prisma.main_famoushumanityreviewdailyfeed.findFirst({

--- a/src/prisma/repositories/feeds.repository.ts
+++ b/src/prisma/repositories/feeds.repository.ts
@@ -104,6 +104,33 @@ export class FeedsRepository {
     });
   }
 
+  public async getReviewWrite(date: Date, userId: number) {
+    return await this.prisma.main_reviewwritedailyuserfeed.findFirst({
+      include: EFeed.ReviewWriteDetails.include,
+      where: {
+        date,
+        user_id: userId,
+      },
+    });
+  }
+
+  public async createReviewWrite(
+    date: Date,
+    userId: number,
+    takenLectureId: number,
+  ) {
+    return await this.prisma.main_reviewwritedailyuserfeed.create({
+      include: EFeed.ReviewWriteDetails.include,
+      data: {
+        date,
+        priority: Math.random(),
+        visible: Math.random() < FeedVisibleRate.ReviewWrite,
+        user_id: userId,
+        lecture_id: takenLectureId,
+      },
+    });
+  }
+
   public async getOrCreateReviewWrite(
     date: Date,
     userId: number,

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { session_userprofile } from '@prisma/client';
+import { review_humanitybestreview, session_userprofile } from '@prisma/client';
 import { ReviewDetails, reviewDetails } from '../../common/schemaTypes/types';
 import { PrismaService } from '../prisma.service';
 
@@ -267,5 +267,15 @@ export class ReviewsRepository {
       },
       take: n,
     });
+  }
+
+  public async getTopNHumanityBestReviews(
+    n: number,
+  ): Promise<review_humanitybestreview> {
+    // Prisma does not support RAND() in ORDER BY.
+    return await this.prisma.$queryRaw`
+        SELECT * FROM review_humanitybestreview 
+        ORDER BY RAND() 
+        LIMIT ${n}`;
   }
 }

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { review_humanitybestreview, session_userprofile } from '@prisma/client';
+import {
+  review_humanitybestreview,
+  review_majorbestreview,
+  session_userprofile,
+  subject_department,
+} from '@prisma/client';
 import { ReviewDetails, reviewDetails } from '../../common/schemaTypes/types';
 import { PrismaService } from '../prisma.service';
 
@@ -269,13 +274,27 @@ export class ReviewsRepository {
     });
   }
 
-  public async getTopNHumanityBestReviews(
+  public async getRandomNHumanityBestReviews(
     n: number,
   ): Promise<review_humanitybestreview> {
     // Prisma does not support RAND() in ORDER BY.
     return await this.prisma.$queryRaw`
-        SELECT * FROM review_humanitybestreview 
-        ORDER BY RAND() 
-        LIMIT ${n}`;
+      SELECT * FROM review_humanitybestreview 
+      ORDER BY RAND() 
+      LIMIT ${n}`;
+  }
+
+  public async getRandomNMajorBestReviews(
+    n: number,
+    department: subject_department,
+  ): Promise<review_majorbestreview[]> {
+    // Prisma does not support RAND() in ORDER BY.
+    return await this.prisma.$queryRaw`
+      SELECT mbr.* FROM review_majorbestreview mbr
+      INNER JOIN review_review r ON r.id = mbr.review_id
+      INNER JOIN subject_lecture l ON l.id = r.lecture_id
+      WHERE l.department_id = ${department.id}
+      ORDER BY RAND() 
+      LIMIT ${n}`;
   }
 }

--- a/src/prisma/repositories/user.repository.ts
+++ b/src/prisma/repositories/user.repository.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  Prisma,
-  session_userprofile,
-  session_userprofile_taken_lectures,
-  subject_semester,
-} from '@prisma/client';
+import { Prisma, session_userprofile, subject_semester } from '@prisma/client';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
@@ -52,8 +47,9 @@ export class UserRepository {
   async getTakenLectures(
     userId: number,
     notWritableSemester?: subject_semester | null,
-  ): Promise<session_userprofile_taken_lectures[]> {
+  ) {
     return await this.prisma.session_userprofile_taken_lectures.findMany({
+      include: { lecture: true },
       where: {
         userprofile_id: userId,
         lecture: {

--- a/src/prisma/repositories/user.repository.ts
+++ b/src/prisma/repositories/user.repository.ts
@@ -3,16 +3,13 @@ import {
   Prisma,
   session_userprofile,
   session_userprofile_taken_lectures,
+  subject_semester,
 } from '@prisma/client';
 import { PrismaService } from '../prisma.service';
-import { SemesterRepository } from './semester.repository';
 
 @Injectable()
 export class UserRepository {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly semesterRepository: SemesterRepository,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async findBySid(sid: string) {
     return await this.prisma.session_userprofile.findFirst({
@@ -52,12 +49,10 @@ export class UserRepository {
     });
   }
 
-  async getReviewWritableTakenLectures(
+  async getTakenLectures(
     userId: number,
+    notWritableSemester?: subject_semester | null,
   ): Promise<session_userprofile_taken_lectures[]> {
-    const notWritableSemester =
-      await this.semesterRepository.getNotWritableSemester();
-
     return await this.prisma.session_userprofile_taken_lectures.findMany({
       where: {
         userprofile_id: userId,


### PR DESCRIPTION
- Repository 사이의 dependency injection을 제거합니다.
  - migration script `addRefreshToken.ts`에서, UserRepository를 생성할 때, semesterRepository가 필요한 부분을 보고 발견
  - feed를 개발하면서 발생한, `semesterRepository in feedRepository` 그리고 `semesterRepository in userRepository`를 제거합니다.

- 추후에 lectureRepository 안에 있는 courseRepository도 제거하면 좋겠습니다.  