### PR TITLE
Implement fetching related reviews of a lecture

### DIFF
--- a/src/modules/lectures/lectures.controller.ts
+++ b/src/modules/lectures/lectures.controller.ts
@@ -45,7 +45,10 @@ export class LecturesController {
     @Param('lectureId') lectureId: number,
     @GetUser() user: session_userprofile,
   ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
-    // TODO
-    throw new Error('Not implemented');
+    return await this.LectureService.getLectureRelatedReviews(
+      user,
+      lectureId,
+      query,
+    );
   }
 }

--- a/src/modules/lectures/lectures.controller.ts
+++ b/src/modules/lectures/lectures.controller.ts
@@ -37,4 +37,15 @@ export class LecturesController {
   ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
     return await this.LectureService.getLectureReviews(user, lectureId, query);
   }
+
+  @Public()
+  @Get(':lectureId/related-reviews')
+  async getLectureRelatedReviews(
+    @Query() query: IReview.LectureReviewsQueryDto,
+    @Param('lectureId') lectureId: number,
+    @GetUser() user: session_userprofile,
+  ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
+    // TODO
+    throw new Error('Not implemented');
+  }
 }

--- a/src/modules/lectures/lectures.controller.ts
+++ b/src/modules/lectures/lectures.controller.ts
@@ -34,6 +34,7 @@ export class LecturesController {
     @Query() query: IReview.LectureReviewsQueryDto,
     @Param('lectureId') lectureId: number,
     @GetUser() user: session_userprofile,
+    // TODO: Consider using IReview.Basic
   ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
     return await this.LectureService.getLectureReviews(user, lectureId, query);
   }
@@ -44,6 +45,7 @@ export class LecturesController {
     @Query() query: IReview.LectureReviewsQueryDto,
     @Param('lectureId') lectureId: number,
     @GetUser() user: session_userprofile,
+    // TODO: Consider using IReview.Basic
   ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
     return await this.LectureService.getLectureRelatedReviews(
       user,

--- a/src/modules/lectures/lectures.service.ts
+++ b/src/modules/lectures/lectures.service.ts
@@ -71,7 +71,7 @@ export class LecturesService {
     lectureId: number,
     query: IReview.LectureReviewsQueryDto,
   ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
-    const MAX_LIMIT = 100;
+    const DEFAULT_LIMIT = 100;
     const DEFAULT_ORDER = ['-written_datetime', '-id'];
 
     const lecture = await this.LectureRepository.getLectureById(lectureId);
@@ -79,7 +79,7 @@ export class LecturesService {
       await this.reviewsRepository.getRelatedReviewsOfLecture(
         query.order ?? DEFAULT_ORDER,
         query.offset ?? 0,
-        query.limit ?? MAX_LIMIT,
+        query.limit ?? DEFAULT_LIMIT,
         lecture,
       );
 

--- a/src/modules/lectures/lectures.service.ts
+++ b/src/modules/lectures/lectures.service.ts
@@ -9,7 +9,7 @@ import { ReviewResponseDto } from 'src/common/interfaces/dto/reviews/review.resp
 import { toJsonLecture } from 'src/common/interfaces/serializer/lecture.serializer';
 import { toJsonReview } from 'src/common/interfaces/serializer/review.serializer';
 import { ReviewsRepository } from 'src/prisma/repositories/review.repository';
-import { LectureDetails } from '../../common/schemaTypes/types';
+import { LectureDetails, ReviewDetails } from '../../common/schemaTypes/types';
 import { LectureRepository } from './../../prisma/repositories/lecture.repository';
 
 @Injectable()
@@ -46,6 +46,43 @@ export class LecturesService {
     );
 
     // TODO: Make this efficient. Get this info together in getReviewsOfLecture
+    return await Promise.all(
+      reviews.map(async (review) => {
+        const result = toJsonReview(review);
+        if (user) {
+          const isLiked: boolean = await this.reviewsRepository.isLiked(
+            review.id,
+            user.id,
+          );
+          return Object.assign(result, {
+            userspecific_is_liked: isLiked,
+          });
+        } else {
+          return Object.assign(result, {
+            userspecific_is_liked: false,
+          });
+        }
+      }),
+    );
+  }
+
+  public async getLectureRelatedReviews(
+    user: session_userprofile,
+    lectureId: number,
+    query: IReview.LectureReviewsQueryDto,
+  ): Promise<(ReviewResponseDto & { userspecific_is_liked: boolean })[]> {
+    const MAX_LIMIT = 100;
+    const DEFAULT_ORDER = ['-written_datetime', '-id'];
+
+    const lecture = await this.LectureRepository.getLectureById(lectureId);
+    const reviews: ReviewDetails[] =
+      await this.reviewsRepository.getRelatedReviewsOfLecture(
+        query.order ?? DEFAULT_ORDER,
+        query.offset ?? 0,
+        query.limit ?? MAX_LIMIT,
+        lecture,
+      );
+
     return await Promise.all(
       reviews.map(async (review) => {
         const result = toJsonReview(review);

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -160,18 +160,6 @@ export class ReviewsRepository {
     limit: number,
     lecture: LectureDetails,
   ): Promise<ReviewDetails[]> {
-    const orderFilter: { [key: string]: string }[] = [];
-    order.forEach((orderList) => {
-      const orderDict: { [key: string]: string } = {};
-      let order = 'asc';
-      const orderBy = orderList.split('-');
-      if (orderBy[0] == '') {
-        order = 'desc';
-      }
-      orderDict[orderBy[orderBy.length - 1]] = order;
-      orderFilter.push(orderDict);
-    });
-
     return await this.prisma.review_review.findMany({
       ...EReview.Details,
       where: {
@@ -190,7 +178,7 @@ export class ReviewsRepository {
       },
       skip: offset,
       take: limit,
-      orderBy: orderFilter,
+      orderBy: orderFilter(order),
       distinct: [
         'id',
         'course_id',

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -7,8 +7,6 @@ import {
 } from '@prisma/client';
 import { EReview } from 'src/common/entities/EReview';
 import { orderFilter } from 'src/common/utils/search.utils';
-import { ECourse } from '../../common/entities/ECourse';
-import { ELecture } from '../../common/entities/ELecture';
 import {
   LectureDetails,
   ReviewDetails,
@@ -175,6 +173,7 @@ export class ReviewsRepository {
     });
 
     return await this.prisma.review_review.findMany({
+      ...EReview.Details,
       where: {
         lecture: {
           course_id: lecture.course_id,
@@ -188,11 +187,6 @@ export class ReviewsRepository {
             },
           },
         },
-      },
-      include: {
-        course: ECourse.Details,
-        lecture: ELecture.Details,
-        review_reviewvote: true,
       },
       skip: offset,
       take: limit,

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -7,7 +7,11 @@ import {
 } from '@prisma/client';
 import { EReview } from 'src/common/entities/EReview';
 import { orderFilter } from 'src/common/utils/search.utils';
-import { ReviewDetails, reviewDetails } from '../../common/schemaTypes/types';
+import {
+  LectureDetails,
+  ReviewDetails,
+  reviewDetails,
+} from '../../common/schemaTypes/types';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
@@ -148,6 +152,15 @@ export class ReviewsRepository {
       skip: offset,
       take: limit,
     });
+  }
+
+  public async getRelatedReviewsOfLecture(
+    order: string[],
+    offset: number,
+    limit: number,
+    lecture: LectureDetails,
+  ): Promise<ReviewDetails[]> {
+    throw new Error('Not implemented');
   }
 
   async isLiked(reviewId: number, userId: number): Promise<boolean> {

--- a/src/prisma/repositories/review.repository.ts
+++ b/src/prisma/repositories/review.repository.ts
@@ -7,6 +7,8 @@ import {
 } from '@prisma/client';
 import { EReview } from 'src/common/entities/EReview';
 import { orderFilter } from 'src/common/utils/search.utils';
+import { ECourse } from '../../common/entities/ECourse';
+import { ELecture } from '../../common/entities/ELecture';
 import {
   LectureDetails,
   ReviewDetails,
@@ -188,22 +190,8 @@ export class ReviewsRepository {
         },
       },
       include: {
-        course: {
-          include: {
-            subject_department: true,
-            subject_course_professors: { include: { professor: true } },
-            lecture: true,
-            subject_courseuser: true,
-          },
-        },
-        lecture: {
-          include: {
-            subject_department: true,
-            subject_lecture_professors: { include: { professor: true } },
-            subject_classtime: true,
-            subject_examtime: true,
-          },
-        },
+        course: ECourse.Details,
+        lecture: ELecture.Details,
         review_reviewvote: true,
       },
       skip: offset,


### PR DESCRIPTION
## Summary

- Implement `GET /api/lectures/:lectureId/related-reviews` ([Link](https://www.notion.so/sparcs/api-lectures-lectureId-related-reviews-7123896458c24573b45be2e665cfd8af?pvs=4))
  - [기존 구현](https://github.com/sparcs-kaist/otlplus/blob/8086f13604f0832fbfc3fd5fa977d61a60c311d5/apps/subject/views.py#L246-L267) 을 참고하면, "related review" 란 대상 lecture와 비교했을 때 course와 professor가 동일한 review를 말합니다.