### PR TITLE
Fix: resolve orderBy error

### DIFF
--- a/src/common/utils/search.utils.ts
+++ b/src/common/utils/search.utils.ts
@@ -41,7 +41,46 @@ export type orderFilterType = {
   [key: string]: orderFilterType | string;
 };
 
+export type relationOrderDict = {
+  [key: string]: relationOrderDict | string;
+};
+
 export function orderFilter(order: string[] | undefined): orderFilterType[] {
+  if (order === undefined) {
+    return [];
+  }
+  const orderFilter: orderFilterType[] = [];
+  order.forEach((str) => {
+    const orderDict: relationOrderDict = {};
+    let order = 'asc';
+    const orderBy = str.split(/-/);
+    console.log(orderBy, str);
+
+    const orderByStr = str.startsWith('-') ? str.split(/-/)[1] : str;
+    if (str.startsWith('-')) {
+      order = 'desc';
+    }
+
+    const orderByList = orderByStr.split('__');
+    if (orderByList.length == 1) {
+      orderDict[orderBy[orderBy.length - 1]] = order;
+      orderFilter.push(orderDict);
+    } else {
+      const relation = orderByList[0];
+      const field = orderByList[1];
+      const fieldDict: relationOrderDict = {};
+      fieldDict[field] = order;
+      orderDict[relation] = fieldDict;
+      orderFilter.push(orderDict);
+    }
+    console.log(orderBy);
+  });
+  return orderFilter;
+}
+
+export function orderFilterLegacy(
+  order: string[] | undefined,
+): orderFilterType[] {
   if (order === undefined) {
     return [];
   }
@@ -53,6 +92,7 @@ export function orderFilter(order: string[] | undefined): orderFilterType[] {
     if (orderBy[0] == '') {
       order = 'desc';
     }
+    console.log(orderBy);
 
     orderDict[orderBy[orderBy.length - 1]] = order;
     orderFilter.push(orderDict);


### PR DESCRIPTION
search Util에서 orderBy 객체를 만드는 곳에서 문제 발생
- 기존 로직: client에서 넘어오는 query 중 order의 구분자인 '-'와 '--'를 딱히 구분하지 않음
- 수정 로직: '-'는 asc,desc, '--'는 relation 여부를 기준으로 구분