### PR TITLE
Issue/119/transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --force
       - name: Check lint
         run: npm run lint:check
 
@@ -57,7 +57,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --force
       - name: Copy env file
         run: cp ./env/.env.example ./env/.env.local
       - name: Generate PrismaClient

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --force
       - name: Check format
         run: npm run format:check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "prettier": "^2.3.2",
         "source-map-support": "^0.5.20",
         "supertest": "^6.1.3",
-        "ts-jest": "28.0.5",
+        "ts-jest": "^28.0.5",
         "ts-loader": "^9.2.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.3.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs-cls/transactional": "^2.4.1",
+        "@nestjs-cls/transactional-adapter-prisma": "^1.2.3",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/jwt": "^10.0.3",
@@ -34,6 +36,7 @@
         "ical-generator": "^7.1.0",
         "moment-timezone": "^0.5.45",
         "morgan": "^1.10.0",
+        "nestjs-cls": "^4.4.0",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "prisma": "4.16.0",
@@ -1310,6 +1313,35 @@
     "node_modules/@microsoft/tsdoc": {
       "version": "0.14.2",
       "license": "MIT"
+    },
+    "node_modules/@nestjs-cls/transactional": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs-cls/transactional/-/transactional-2.4.2.tgz",
+      "integrity": "sha512-bQZ4Xo5BOPnmKcBk/Qsh/VX8kHr+fKTfJ6Fcxu/RGmxzSwjRVgShNu0E57V8CZkZJ6YuIKJoDQHAoIbeRIffbQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "> 7.0.0 < 11",
+        "@nestjs/core": "> 7.0.0 < 11",
+        "nestjs-cls": "^4.4.1",
+        "reflect-metadata": "*",
+        "rxjs": ">= 7"
+      }
+    },
+    "node_modules/@nestjs-cls/transactional-adapter-prisma": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nestjs-cls/transactional-adapter-prisma/-/transactional-adapter-prisma-1.2.4.tgz",
+      "integrity": "sha512-W/Ej+T3QG81//d4YuXsuHnV9WFvWTQBQk1BSiowyq7d812lyr3zk8ZMwmAhB7JAY80cJMeBY6i3TBlP0QVIczQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@nestjs-cls/transactional": "^2.4.2",
+        "@prisma/client": "> 4 < 6",
+        "nestjs-cls": "^4.4.1",
+        "prisma": "> 4 < 6"
+      }
     },
     "node_modules/@nestjs/cli": {
       "version": "9.5.0",
@@ -6706,6 +6738,20 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nestjs-cls": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-4.4.1.tgz",
+      "integrity": "sha512-4yhldwm/cJ02lQ8ZAdM8KQ7gMfjAc1z3fo5QAQgXNyN4N6X5So9BCwv+BTLRugDCkELUo3qtzQHnKhGYL/ftPg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "> 7.0.0 < 11",
+        "@nestjs/core": "> 7.0.0 < 11",
+        "reflect-metadata": "*",
+        "rxjs": ">= 7"
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
-    "ts-jest": "28.0.5",
+    "ts-jest": "^28.0.5",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "schema": "src/prisma/schema.prisma"
   },
   "dependencies": {
+    "@nestjs-cls/transactional": "^2.4.1",
+    "@nestjs-cls/transactional-adapter-prisma": "^1.2.3",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/jwt": "^10.0.3",
@@ -63,6 +65,7 @@
     "ical-generator": "^7.1.0",
     "moment-timezone": "^0.5.45",
     "morgan": "^1.10.0",
+    "nestjs-cls": "^4.4.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "prisma": "4.16.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { ShareModule } from './modules/share/share.module';
 import { AuthConfig } from './modules/auth/auth.config';
 import { AuthGuard } from './modules/auth/guard/auth.guard';
+import { ClsModule } from 'nestjs-cls';
+import { ClsPluginTransactional } from '@nestjs-cls/transactional';
+import { PrismaService } from '@src/prisma/prisma.service';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 
 @Module({
   imports: [
@@ -46,6 +50,18 @@ import { AuthGuard } from './modules/auth/guard/auth.guard';
     PlannersModule,
     TracksModule,
     ShareModule,
+    ClsModule.forRoot({
+      global: true,
+      middleware: { mount: true },
+      plugins: [
+        new ClsPluginTransactional({
+          imports: [PrismaModule],
+          adapter: new TransactionalAdapterPrisma({
+            prismaInjectionToken: PrismaService,
+          }),
+        }),
+      ],
+    }),
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -10,11 +10,13 @@ import {
 } from '../../common/interfaces/serializer/course.serializer';
 import { getRepresentativeLecture } from '../../common/utils/lecture.utils';
 import { CourseRepository } from './../../prisma/repositories/course.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class CoursesService {
   constructor(private readonly courseRepository: CourseRepository) {}
 
+  @Transactional()
   public async getCourses(
     query: ICourse.Query,
     user: session_userprofile,

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -43,6 +43,16 @@ export class CoursesService {
     );
   }
 
+  @Transactional()
+  public async getCourseByIds(ids: number[], user: session_userprofile) {
+    return await Promise.all(
+      ids.map(async (id) => {
+        return this.courseRepository.getCourseById(id);
+      }),
+    );
+  }
+
+  @Transactional()
   public async getCourseById(id: number, user: session_userprofile) {
     const course = await this.courseRepository.getCourseById(id);
     if (!course) {

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -142,6 +142,7 @@ export class CoursesService {
     }
   }
 
+  @Transactional()
   async readCourse(userId: number, courseId: number) {
     await this.courseRepository.readCourse(userId, courseId);
   }

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -45,10 +45,8 @@ export class CoursesService {
 
   @Transactional()
   public async getCourseByIds(ids: number[], user: session_userprofile) {
-    return await Promise.all(
-      ids.map(async (id) => {
-        return this.courseRepository.getCourseById(id);
-      }),
+    return Promise.all(
+      ids.map((id) => this.courseRepository.getCourseById(id)),
     );
   }
 

--- a/src/modules/planners/planners.service.ts
+++ b/src/modules/planners/planners.service.ts
@@ -18,6 +18,7 @@ import { LectureRepository } from 'src/prisma/repositories/lecture.repository';
 import { PlannerRepository } from 'src/prisma/repositories/planner.repository';
 import { EPlanners } from '../../common/entities/EPlanners';
 import { CourseRepository } from './../../prisma/repositories/course.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class PlannersService {
@@ -43,6 +44,7 @@ export class PlannersService {
     return await this.PlannerRepository.getRelatedPlanner(user);
   }
 
+  @Transactional()
   public async postPlanner(
     body: IPlanner.CreateBodyDto,
     user: session_userprofile,
@@ -115,6 +117,7 @@ export class PlannersService {
     return toJsonPlanner(planner);
   }
 
+  @Transactional()
   async addArbitraryItem(
     plannerId: number,
     body: IPlanner.AddArbitraryItemDto,
@@ -142,6 +145,7 @@ export class PlannersService {
     return toJsonArbitraryItem(arbitraryItem);
   }
 
+  @Transactional()
   public async removePlannerItem(
     plannerId: number,
     removeItem: IPlanner.RemoveItemBodyDto,
@@ -190,6 +194,7 @@ export class PlannersService {
     return toJsonPlanner(planner);
   }
 
+  @Transactional()
   async createFuturePlannerItem(
     plannerId: number,
     year: number,
@@ -218,6 +223,7 @@ export class PlannersService {
     return toJsonFutureItem(item);
   }
 
+  @Transactional()
   public async reorderPlanner(
     plannerId: number,
     order: number,
@@ -256,6 +262,7 @@ export class PlannersService {
     return toJsonPlanner(updated);
   }
 
+  @Transactional()
   async updatePlannerItem(
     plannerId: number,
     updateItemDto: IPlanner.UpdateItemBodyDto,

--- a/src/modules/rates/rates.service.ts
+++ b/src/modules/rates/rates.service.ts
@@ -3,10 +3,12 @@ import { session_userprofile, support_rate } from '@prisma/client';
 import { IRate } from 'src/common/interfaces/IRate';
 import { RateRepository } from 'src/prisma/repositories/rates.repository';
 import settings from 'src/settings';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class RatesService {
   constructor(private readonly rateRepository: RateRepository) {}
+  @Transactional()
   async createRate(
     body: IRate.CreateDto,
     user: session_userprofile,

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -4,6 +4,7 @@ import { IReview } from 'src/common/interfaces/IReview';
 import { toJsonReview } from 'src/common/interfaces/serializer/review.serializer';
 import { LectureRepository } from 'src/prisma/repositories/lecture.repository';
 import { ReviewsRepository } from 'src/prisma/repositories/review.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class ReviewsService {
@@ -76,6 +77,7 @@ export class ReviewsService {
     );
   }
 
+  @Transactional()
   async createReviews(
     reviewsBody: IReview.CreateDto,
     user: session_userprofile,
@@ -112,6 +114,7 @@ export class ReviewsService {
     }
   }
 
+  @Transactional()
   async updateReviewById(
     reviewId: number,
     user: session_userprofile,
@@ -162,6 +165,7 @@ export class ReviewsService {
     return isLiked;
   }
 
+  @Transactional()
   async createReviewVote(reviewId: number, user: session_userprofile) {
     await this.reviewsRepository.upsertReviewVote(reviewId, user.id);
     return null;

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -8,9 +8,6 @@ export class SessionService {
 
   @Transactional()
   async changeFavoriteDepartments(userId: number, departmentIds: number[]) {
-    return await this.userRepository.changeFavoriteDepartments(
-      userId,
-      departmentIds,
-    );
+    return this.userRepository.changeFavoriteDepartments(userId, departmentIds);
   }
 }

--- a/src/modules/session/session.service.ts
+++ b/src/modules/session/session.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { UserRepository } from 'src/prisma/repositories/user.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class SessionService {
   constructor(private readonly userRepository: UserRepository) {}
 
+  @Transactional()
   async changeFavoriteDepartments(userId: number, departmentIds: number[]) {
     return await this.userRepository.changeFavoriteDepartments(
       userId,

--- a/src/modules/timetables/timetables.service.ts
+++ b/src/modules/timetables/timetables.service.ts
@@ -15,6 +15,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { LectureRepository } from '../../prisma/repositories/lecture.repository';
 import { SemesterRepository } from '../../prisma/repositories/semester.repository';
 import { TimetableRepository } from '../../prisma/repositories/timetable.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class TimetablesService {
@@ -48,6 +49,7 @@ export class TimetablesService {
     return await this.timetableRepository.getTimeTableById(timetableId);
   }
 
+  @Transactional()
   async createTimetable(
     timeTableBody: ITimetable.CreateDto,
     user: session_userprofile,
@@ -96,6 +98,7 @@ export class TimetablesService {
     );
   }
 
+  @Transactional()
   async addLectureToTimetable(
     timeTableId: number,
     body: ITimetable.AddLectureDto,
@@ -126,6 +129,7 @@ export class TimetablesService {
     return await this.timetableRepository.getTimeTableById(timeTableId);
   }
 
+  @Transactional()
   async removeLectureFromTimetable(
     timeTableId: number,
     body: ITimetable.AddLectureDto,
@@ -156,6 +160,7 @@ export class TimetablesService {
     return await this.timetableRepository.getTimeTableById(timeTableId);
   }
 
+  @Transactional()
   async deleteTimetable(user: session_userprofile, timetableId: number) {
     return await this.prismaService.$transaction(async (tx) => {
       const { semester, year, arrange_order } =
@@ -185,6 +190,7 @@ export class TimetablesService {
     });
   }
 
+  @Transactional()
   async reorderTimetable(
     user: session_userprofile,
     timetableId: number,

--- a/src/modules/wishlist/wishlist.service.ts
+++ b/src/modules/wishlist/wishlist.service.ts
@@ -6,6 +6,7 @@ import {
 import { IWishlist } from 'src/common/interfaces/IWishlist';
 import { LectureRepository } from 'src/prisma/repositories/lecture.repository';
 import { WishlistRepository } from 'src/prisma/repositories/wishlist.repository';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class WishlistService {
@@ -18,6 +19,7 @@ export class WishlistService {
     return await this.wishlistRepository.getOrCreateWishlist(userId);
   }
 
+  @Transactional()
   async addLecture(userId: number, body: IWishlist.AddLectureDto) {
     const wishlist = await this.wishlistRepository.getOrCreateWishlist(userId);
 
@@ -42,6 +44,7 @@ export class WishlistService {
     return updatedWishlist;
   }
 
+  @Transactional()
   async removeLecture(userId: number, body: IWishlist.RemoveLectureDto) {
     const wishlist = await this.wishlistRepository.getOrCreateWishlist(userId);
 

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -20,6 +20,7 @@ import { TimetableRepository } from './repositories/timetable.repository';
 import { TracksRepository } from './repositories/track.repository';
 import { UserRepository } from './repositories/user.repository';
 import { WishlistRepository } from './repositories/wishlist.repository';
+import { TranManager } from './transactionManager';
 
 // const extendPrismaClient = {
 //   provide: PrismaService,
@@ -44,6 +45,8 @@ import { WishlistRepository } from './repositories/wishlist.repository';
     PlannerRepository,
     TracksRepository,
     NoticesRepository,
+    ReviewMiddleware,
+    TranManager,
   ],
   exports: [
     PrismaService,

--- a/src/prisma/transactionManager.ts
+++ b/src/prisma/transactionManager.ts
@@ -1,0 +1,33 @@
+import { ModuleRef } from '@nestjs/core';
+import { Injectable } from '@nestjs/common';
+import * as runtime from '@prisma/client/runtime/library';
+import { PrismaClient } from '@prisma/client';
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class TranManager {
+  private static staticPrismaService: PrismaService;
+  private static txClient: Omit<PrismaClient, runtime.ITXClientDenyList>;
+
+  constructor(
+    private readonly ref: ModuleRef,
+    private readonly prismaService: PrismaService,
+  ) {
+    TranManager.staticPrismaService = prismaService;
+  }
+
+  public static async transaction(bizLogic: () => unknown) {
+    const prisma = this.staticPrismaService;
+    return await prisma.$transaction(async (tx) => {
+      TranManager.saveTx(tx);
+      return bizLogic();
+    });
+  }
+  private static saveTx(tx: Omit<PrismaClient, runtime.ITXClientDenyList>) {
+    this.txClient = tx;
+  }
+
+  public static getTx() {
+    return TranManager.txClient ?? TranManager.staticPrismaService;
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,12 +39,7 @@ const getPrismaConfig = (): PrismaClientOptions => {
       },
     },
     errorFormat: 'pretty',
-    log: [
-      {
-        emit: 'event',
-        level: 'query',
-      },
-    ],
+    log: ['query', 'info', 'warn'],
   };
 };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,24 @@ const getPrismaConfig = (): PrismaClientOptions => {
       },
     },
     errorFormat: 'pretty',
-    log: ['query', 'info', 'warn'],
+    log: [
+      {
+        emit: 'event',
+        level: 'query',
+      },
+      {
+        emit: 'stdout',
+        level: 'error',
+      },
+      {
+        emit: 'stdout',
+        level: 'info',
+      },
+      {
+        emit: 'stdout',
+        level: 'warn',
+      },
+    ],
   };
 };
 

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -20,7 +20,7 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/session/info (GET)', async () => {
+  it('tranManager', async () => {
     const courseRepository = app.get(CourseRepository);
     console.log('transaction test with tranManager');
 
@@ -29,6 +29,66 @@ describe('AppController (e2e)', () => {
       await courseRepository.getCourseById(11);
     });
   }, 10000);
+
+  it('tranManager multi request', async () => {
+    const courseRepository = app.get(CourseRepository);
+    console.log('transaction test with tranManager, multi request');
+
+    await Promise.all([
+      TranManager.transaction(async () => {
+        console.log('batch 1');
+        await courseRepository.getCourseById(10);
+        await courseRepository.getCourseById(11);
+      }),
+      TranManager.transaction(async () => {
+        console.log('batch 2');
+        await courseRepository.getCourseById(12);
+        await courseRepository.getCourseById(13);
+        throw Error('test error');
+      }),
+    ]);
+  }, 10000);
+
+  it('TranManager multi request, propagation', async () => {
+    const courseRepository = app.get(CourseRepository);
+    console.log('transaction test with tranManager, multi request propagation');
+    const prisma = app.get(PrismaService);
+    await Promise.all([
+      TranManager.transaction(async () => {
+        console.log('batch 1');
+        await TranManager.getTx().subject_course.findFirst({
+          where: {
+            id: 10,
+          },
+        });
+        console.log(TranManager.getTx());
+        await TranManager.getTx().subject_course.findFirst({
+          where: {
+            id: 11,
+          },
+        });
+        console.log(TranManager.getTx());
+      }),
+      TranManager.transaction(async () => {
+        console.log('batch 2');
+        await TranManager.getTx().subject_course.findFirst({
+          where: {
+            id: 12,
+          },
+        });
+        console.log(TranManager.getTx());
+
+        await TranManager.getTx().subject_course.findFirst({
+          where: {
+            id: 13,
+          },
+        });
+        console.log(TranManager.getTx());
+
+        throw Error('test error');
+      }),
+    ]);
+  });
 
   it('$transaction', async () => {
     console.log('transaction test with prismaService');
@@ -60,5 +120,21 @@ describe('AppController (e2e)', () => {
         },
       })) as session_userprofile;
     const courses = await coursesService.getCourses({ keyword: '기계' }, user);
+  });
+
+  it('transaction test with cls, multi request', async () => {
+    console.log('transaction test with cls, multi request');
+    const prismaService = app.get(PrismaService);
+    const coursesService = app.get(CoursesService);
+    const user: session_userprofile =
+      (await prismaService.session_userprofile.findUnique({
+        where: {
+          id: 13933,
+        },
+      })) as session_userprofile;
+    await Promise.all([
+      coursesService.getCourseByIds([10, 11], user),
+      coursesService.getCourseByIds([12, 13], user),
+    ]);
   });
 });

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -5,6 +5,8 @@ import { PrismaService } from '../src/prisma/prisma.service';
 import { TranManager } from '../src/prisma/transactionManager';
 import { CourseRepository } from '../src/prisma/repositories/course.repository';
 import { ECourse } from '@src/common/entities/ECourse';
+import { CoursesService } from '@src/modules/courses/courses.service';
+import { session_userprofile } from '@prisma/client';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -20,6 +22,7 @@ describe('AppController (e2e)', () => {
 
   it('/session/info (GET)', async () => {
     const courseRepository = app.get(CourseRepository);
+    console.log('transaction test with tranManager');
 
     await TranManager.transaction(async () => {
       await courseRepository.getCourseById(10);
@@ -28,6 +31,7 @@ describe('AppController (e2e)', () => {
   }, 10000);
 
   it('$transaction', async () => {
+    console.log('transaction test with prismaService');
     const prismaService = app.get(PrismaService);
     await prismaService.$transaction(async (tx) => {
       await tx.subject_course.findUnique({
@@ -44,4 +48,17 @@ describe('AppController (e2e)', () => {
       });
     });
   }, 10000);
+
+  it('transaction test with cls', async () => {
+    console.log('transaction test with cls');
+    const prismaService = app.get(PrismaService);
+    const coursesService = app.get(CoursesService);
+    const user: session_userprofile =
+      (await prismaService.session_userprofile.findUnique({
+        where: {
+          id: 13933,
+        },
+      })) as session_userprofile;
+    const courses = await coursesService.getCourses({ keyword: '기계' }, user);
+  });
 });

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -1,0 +1,47 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { TranManager } from '../src/prisma/transactionManager';
+import { CourseRepository } from '../src/prisma/repositories/course.repository';
+import { ECourse } from '@src/common/entities/ECourse';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/session/info (GET)', async () => {
+    const courseRepository = app.get(CourseRepository);
+
+    await TranManager.transaction(async () => {
+      await courseRepository.getCourseById(10);
+      await courseRepository.getCourseById(11);
+    });
+  }, 10000);
+
+  it('$transaction', async () => {
+    const prismaService = app.get(PrismaService);
+    await prismaService.$transaction(async (tx) => {
+      await tx.subject_course.findUnique({
+        include: ECourse.Details.include,
+        where: {
+          id: 10,
+        },
+      });
+      await tx.subject_course.findUnique({
+        include: ECourse.Details.include,
+        where: {
+          id: 11,
+        },
+      });
+    });
+  }, 10000);
+});


### PR DESCRIPTION
2가지 구현을 완료했습니다.
1. TranManager
2. CLS Module을 이용한 방식

TranManager는 처음에 Init 될 때 prismaService를 주입받은 후, transaction이라는 함수를 호출할 때마다 주입받은 prismaService에서 transaction을 시작하고 추가적인 로직을 실행하는 식으로 동작합니다.

CLS 방식은 continuation-local-storage의 약자로, 싱글 쓰레드로 동작하는 node.js에서 request 단위로 무언가를 저장하거나 식별하기가 어려운 문제를 해결하는 방식입니다.

두 개 중에서 선호되는 것은 CLS 방식입니다.
이유는 다음과 같은데요.
1. TranManager에서 transaction propagation(https://mangkyu.tistory.com/269) 과 같은 걸 구현하려고 getTx가 있는데, 이게 새로운 transaction이 실행될 때마다 static property를 갈아끼우는 식으로 구현되어있다보니, 여러 요청이 들어왔을 때, 정상적인 request의 transaction을 물고 갈지 의문입니다. (예를 들어, A를 처리하던 중, B가 시작되고 이 때 A에서 getTx()를 호출하면 다른 transaction을 물고가나?)
2. prisma에는 같은 틱 상에서 findUnique를 하게 되면 그 두 개는 in으로 묶어서 처리해주는 방식이 있습니다. (https://www.prisma.io/docs/orm/prisma-client/queries/query-optimization-performance). 이 방식으로 테스트 코드를 짜봤는데, TranManager는 트랜잭션으로 격리가 안 된채로 조회가 되더라고요. (10,11) / (12,13) 두 개를 각각 Transaction을 걸고 Promis.all로 같이 날렸더니 쿼리는 (10,12), (11,13)으로 날라감. 반면 이 부분은 CLS는 의도한대로 (10,11) / (12,13) 이렇게 잘 날라감.
3. 다만 CLS는 지금 설치가... 잘 안 되서 npm install --force를 해야합니다....