### PR TITLE
fix: course search adjust to new code

### DIFF
--- a/src/common/utils/search.utils.ts
+++ b/src/common/utils/search.utils.ts
@@ -85,3 +85,19 @@ export async function validateYearAndSemester(
     (2009 < year && year < 2018 && semester && [1, 3].includes(semester))
   );
 }
+
+export function formatNewLectureCodeWithDot(keyword: string): string {
+  // new_code의 .을 수용할 수 있게 과목코드를 바꿔주는 함수
+
+  // 정규식: [알파벳]+[숫자]+ 형식 매칭
+  const regex = /^([a-zA-Z]+)(\d+)$/;
+
+  // 키워드가 정규식에 매칭되면 변환, 매칭되지 않으면 원래 값을 반환
+  const match = keyword.match(regex);
+  if (match) {
+    const [, letters, numbers] = match; // 알파벳 그룹과 숫자 그룹 추출
+    return `${letters}.${numbers}`; // 알파벳과 숫자 사이에 '.' 삽입
+  }
+
+  return keyword; // 변환 불가능한 경우 원래 키워드 반환
+}

--- a/src/prisma/repositories/course.repository.ts
+++ b/src/prisma/repositories/course.repository.ts
@@ -7,6 +7,7 @@ import { ICourse } from 'src/common/interfaces';
 import {
   applyOffset,
   applyOrder,
+  formatNewLectureCodeWithDot,
   orderFilter,
 } from 'src/common/utils/search.utils';
 import { PrismaService } from '../prisma.service';
@@ -315,7 +316,7 @@ export class CourseRepository {
 
     const new_code_filter = {
       new_code: {
-        contains: this.formatNewLectureCodeWithDot(keyword_space_removed),
+        contains: formatNewLectureCodeWithDot(keyword_space_removed),
       },
     };
     return {
@@ -492,23 +493,5 @@ export class CourseRepository {
       courseUser.subject_course.latest_written_datetime >
       courseUser.latest_read_datetime
     );
-  }
-
-  formatNewLectureCodeWithDot(keyword: string): string {
-    // new_code의 .을 수용할 수 있게 과목코드를 바꿔주는 함수
-    // utils/search.utils 로 옮길까요??
-    // OR public 이나 private 등의 기타 요건이 필요할까요??
-
-    // 정규식: [알파벳]+[숫자]+ 형식 매칭
-    const regex = /^([a-zA-Z]+)(\d+)$/;
-
-    // 키워드가 정규식에 매칭되면 변환, 매칭되지 않으면 원래 값을 반환
-    const match = keyword.match(regex);
-    if (match) {
-      const [, letters, numbers] = match; // 알파벳 그룹과 숫자 그룹 추출
-      return `${letters}.${numbers}`; // 알파벳과 숫자 사이에 '.' 삽입
-    }
-
-    return keyword; // 변환 불가능한 경우 원래 키워드 반환
   }
 }

--- a/src/prisma/repositories/course.repository.ts
+++ b/src/prisma/repositories/course.repository.ts
@@ -312,11 +312,18 @@ export class CourseRepository {
         contains: keyword_space_removed,
       },
     };
+
+    const new_code_filter = {
+      new_code: {
+        contains: this.formatNewLectureCodeWithDot(keyword_space_removed),
+      },
+    };
     return {
       OR: [
         title_filter,
         en_title_filter,
         old_code_filter,
+        new_code_filter,
         department_name_filter,
         department_name_en_filter,
         professors_professor_name_filter,
@@ -485,5 +492,23 @@ export class CourseRepository {
       courseUser.subject_course.latest_written_datetime >
       courseUser.latest_read_datetime
     );
+  }
+
+  formatNewLectureCodeWithDot(keyword: string): string {
+    // new_code의 .을 수용할 수 있게 과목코드를 바꿔주는 함수
+    // utils/search.utils 로 옮길까요??
+    // OR public 이나 private 등의 기타 요건이 필요할까요??
+
+    // 정규식: [알파벳]+[숫자]+ 형식 매칭
+    const regex = /^([a-zA-Z]+)(\d+)$/;
+
+    // 키워드가 정규식에 매칭되면 변환, 매칭되지 않으면 원래 값을 반환
+    const match = keyword.match(regex);
+    if (match) {
+      const [, letters, numbers] = match; // 알파벳 그룹과 숫자 그룹 추출
+      return `${letters}.${numbers}`; // 알파벳과 숫자 사이에 '.' 삽입
+    }
+
+    return keyword; // 변환 불가능한 경우 원래 키워드 반환
   }
 }


### PR DESCRIPTION
new code도 검색이 되도록 하였습니다.

1. new code를 keywordFilter에서 반환합니다.
2. course repository에 formatNewLectureCodeWithDot 함수로 keyword를 [알파벳][숫자] 로 입력한 과목 코드 검색의 경우 자동으로 . 을 넣어서 new code로 검색합니다.