### PR TITLE
Fix: lecture sync error due to missing old_code

### DIFF
--- a/src/modules/sync/syncScholarDB.service.ts
+++ b/src/modules/sync/syncScholarDB.service.ts
@@ -320,14 +320,14 @@ export class SyncScholarDBService {
     return {
       id: lecture.DEPT_ID,
       num_id: lecture.SUBJECT_NO.split('.')[0], // TODO: num_id is obsolete. It equals code, and should be removed later.
-      code: this.extract_dept_code(lecture.OLD_NO), // TODO: May need to extract from new SUBJECT_NO
+      code: this.extract_dept_code(lecture.SUBJECT_NO), // TODO: May need to extract from new SUBJECT_NO
       name: lecture.DEPT_NAME,
       name_en: lecture.E_DEPT_NAME,
     };
   }
 
   extract_dept_code(lectureCode: string) {
-    const code = lectureCode.match(/([a-zA-Z]+)(\d+)/)?.[1];
+    const code = lectureCode.match(/[a-zA-Z]+|\d+/g)?.[0];
     if (!code)
       throw new Error(`Failed to extract department code from ${lectureCode}`);
     return code;

--- a/src/modules/sync/syncScholarDB.service.ts
+++ b/src/modules/sync/syncScholarDB.service.ts
@@ -227,17 +227,12 @@ export class SyncScholarDBService {
     const notExistingLectures = new Set(existingLectures.map((l) => l.id));
     for (const lecture of data.lectures) {
       try {
-        const foundLecture = existingLectures.find((l) =>
-          // 차세대 학사시스템 이후 신설된 과목은 OLD_NO의 값이 ""로 모두 같음.
-          l.old_code === ''
-            ? l.new_code === lecture.SUBJECT_NO &&
-              l.class_no.trim() === lecture.LECTURE_CLASS.trim()
-            : l.old_code === lecture.OLD_NO &&
-              l.class_no.trim() === lecture.LECTURE_CLASS.trim(),
+        const foundLecture = existingLectures.find(
+          (l) =>
+            l.new_code === lecture.SUBJECT_NO &&
+            l.class_no.trim() === lecture.LECTURE_CLASS.trim(),
         );
-        const course_id = courseMap.get(
-          lecture.OLD_NO === '' ? lecture.SUBJECT_NO : lecture.OLD_NO,
-        )?.id;
+        const course_id = courseMap.get(lecture.SUBJECT_NO)?.id;
         if (!course_id)
           throw new Error(`Course not found for lecture ${lecture.SUBJECT_NO}`);
         const derivedLecture = this.deriveLectureInfo(lecture, course_id);
@@ -425,7 +420,8 @@ export class SyncScholarDBService {
 
   lectureChanged(lecture: ELecture.Details, newData: DerivedLectureInfo) {
     return (
-      lecture.code !== newData.code || // TODO: This can be problematic if multiple lectures have the same old code
+      // TODO: This can be problematic if multiple lectures have the same old code
+      // -> new_code(=code)를 기준으로 lecture 구분하므로 code가 다르면 다른 lecture로 취급해야 함
       lecture.year !== newData.year ||
       lecture.semester !== newData.semester ||
       lecture.class_no !== newData.class_no ||

--- a/src/prisma/repositories/sync.repository.ts
+++ b/src/prisma/repositories/sync.repository.ts
@@ -92,6 +92,12 @@ export class SyncRepository {
     });
   }
 
+  async getExistingCoursesByNewCodes(newCodes: string[]) {
+    return await this.prisma.subject_course.findMany({
+      where: { new_code: { in: newCodes } },
+    });
+  }
+
   async createCourse(data: LectureDerivedCourseInfo) {
     return await this.prisma.subject_course.create({
       data: {


### PR DESCRIPTION
### 개요
2025년에 신설되어 OLD_NO가 없는 lecture에 대해, sync 과정에서 발생하는 문제를 수정하였습니다.

### 수정 사항

- old_code 대신 new_code를 기준으로 courseMap을 작성하도록 수정
- department code를 OLD_NO 대신 SUBJECT_NO에서 추출하도록 수정
- OLD_NO(old_code) 대신 SUBJECT_NO(new_code)를 기준으로 foundLecture를 판단하도록 수정

### 테스트
- 기존에 문제가 발생했던 DHS.32201, HSS.32201, AE.94307, AE.94308이 정상적으로 검색 및 시간표에 등록되는 것을 로컬 환경에서 확인하였습니다. 
- sync 과정에서 error가 발생하지 않는 것을 로컬 환경에서 확인하였습니다.