### PR TITLE
fix: add allowPublicKeyRetrieval

### DIFF
--- a/apps/notification-consumer/src/settings.ts
+++ b/apps/notification-consumer/src/settings.ts
@@ -17,6 +17,7 @@ const getPrismaConnectConfig = (): mariadb.PoolConfig => ({
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
   connectionLimit: 20,
+  allowPublicKeyRetrieval: true,
 })
 
 const getFirebaseConfig = (): ServiceAccount => {

--- a/apps/scholar-sync/src/settings.ts
+++ b/apps/scholar-sync/src/settings.ts
@@ -46,6 +46,7 @@ const getPrismaConnectConfig = (): mariadb.PoolConfig => ({
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
   connectionLimit: 10,
+  allowPublicKeyRetrieval: true,
 })
 
 const getSyncConfig = () => ({

--- a/apps/server-consumer/src/settings.ts
+++ b/apps/server-consumer/src/settings.ts
@@ -13,6 +13,7 @@ const getPrismaConnectConfig = (): mariadb.PoolConfig => ({
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
   connectionLimit: 5,
+  allowPublicKeyRetrieval: true,
 })
 
 const sentryConfig = () => ({

--- a/apps/server/src/bootstrap/bootstrap.ts
+++ b/apps/server/src/bootstrap/bootstrap.ts
@@ -1,4 +1,6 @@
-import { HttpException, ValidationPipe, VersioningType } from '@nestjs/common'
+import {
+  HttpException, HttpStatus, ValidationPipe, VersioningType,
+} from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import * as Sentry from '@sentry/nestjs'
 import cookieParser from 'cookie-parser'
@@ -44,6 +46,13 @@ async function bootstrap() {
     // Add Tracing by setting tracesSampleRate
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
+    beforeSend(event, hint) {
+      const error = hint?.originalException
+      if (error instanceof HttpException && error.getStatus() === HttpStatus.UNAUTHORIZED) {
+        return null
+      }
+      return event
+    },
   })
 
   const app = await NestFactory.create(AppModule)

--- a/apps/server/src/settings.ts
+++ b/apps/server/src/settings.ts
@@ -52,6 +52,7 @@ const getPrismaConnectConfig = (): mariadb.PoolConfig => ({
   connectionLimit: 40,
   idleTimeout: 600,
   minDelayValidation: 10000,
+  allowPublicKeyRetrieval: true,
 })
 
 const getRedisConfig = () => ({

--- a/libs/common/src/exception/exception.filter.ts
+++ b/libs/common/src/exception/exception.filter.ts
@@ -104,7 +104,7 @@ export class HttpExceptionFilter<T extends HttpException> implements ExceptionFi
       })
 
       scope.setContext('response', {
-        statusCode: 500,
+        statusCode: resStatus,
       })
       Sentry.captureException(exception)
     })


### PR DESCRIPTION
## Summary                                                                    
  - MySQL 8.0 재시작 시 `caching_sha2_password` 인증 캐시가 초기화되면서 mariadb
   드라이버가 커넥션을 생성하지 못하는 문제 수정                                
  - 4개 앱(server, server-consumer, scholar-sync, notification-consumer)의 DB   
  pool 설정에 `allowPublicKeyRetrieval: true` 추가                              
                                                            
## Root Cause                                                                 
  - MySQL 8.0의 `caching_sha2_password`는 인증 캐시가 있으면 fast path로 비TLS
  연결 허용                                                                     
  - 서버 재시작 시 캐시 초기화 → full auth 필요 → RSA 공개키 교환 필요
  - `allowPublicKeyRetrieval` 옵션 미설정으로 드라이버가 RSA 키를 가져오지 못해 
  `pool timeout (active=0 idle=0 limit=40)` 발생                                