### PR TITLE
fix: serialize courses with a missing representative lecture

### DIFF
--- a/apps/server/src/common/serializer/course.serializer.spec.ts
+++ b/apps/server/src/common/serializer/course.serializer.spec.ts
@@ -1,0 +1,51 @@
+import { subject_lecture } from '@prisma/client'
+
+import { toJsonCourseBasic } from './course.serializer'
+
+const course = {
+  id: 24754,
+  old_code: 'AIC.20101',
+  new_code: 'AIC.20101',
+  type: '전공필수',
+  type_en: 'Major Required',
+  title: '딥러닝 개론',
+  title_en: 'Introduction to Deep Learning',
+  summury: '',
+  review_total_weight: 0,
+  subject_department: {
+    id: 24354,
+    name: 'AI컴퓨팅학과',
+    name_en: 'AI Computing',
+    code: 'AIC',
+    num_courses: 0,
+    posY: 0,
+  },
+} as unknown as Parameters<typeof toJsonCourseBasic>[0]
+
+const lecture = {
+  credit: 3,
+  credit_au: 1,
+  num_classes: 3,
+  num_labs: 0,
+} as unknown as subject_lecture
+
+describe('toJsonCourseBasic', () => {
+  it('serializes credits from the representative lecture', () => {
+    const result = toJsonCourseBasic(course, lecture)
+
+    expect(result.credit).toBe(3)
+    expect(result.credit_au).toBe(1)
+    expect(result.num_classes).toBe(3)
+    expect(result.num_labs).toBe(0)
+  })
+
+  it('serializes a course whose representative lecture is missing', () => {
+    const result = toJsonCourseBasic(course, undefined)
+
+    expect(result.id).toBe(24754)
+    expect(result.credit).toBe(0)
+    expect(result.credit_au).toBe(0)
+    expect(result.num_classes).toBe(0)
+    expect(result.num_labs).toBe(0)
+  })
+})

--- a/apps/server/src/common/serializer/course.serializer.ts
+++ b/apps/server/src/common/serializer/course.serializer.ts
@@ -40,11 +40,8 @@ export function toJsonFeedRelated(course: subject_course): ICourse.FeedRelated {
 
 export function toJsonCourseBasic(
   course: Omit<ECourse.Extended, 'subject_course_professors'>,
-  lecture: subject_lecture,
+  lecture: subject_lecture | undefined,
 ): ICourse.Basic {
-  if (!lecture) {
-    console.log(course, lecture)
-  }
   return {
     id: course.id,
     old_old_code: course.old_code,
@@ -56,16 +53,16 @@ export function toJsonCourseBasic(
     title_en: course.title_en,
     summary: course.summury, // Todo: fix summury typo in db.
     review_total_weight: course.review_total_weight + 0.000001,
-    credit: lecture.credit ?? 0,
-    credit_au: lecture.credit_au ?? 0,
-    num_classes: lecture.num_classes ?? 0,
-    num_labs: lecture.num_labs ?? 0,
+    credit: lecture?.credit ?? 0,
+    credit_au: lecture?.credit_au ?? 0,
+    num_classes: lecture?.num_classes ?? 0,
+    num_labs: lecture?.num_labs ?? 0,
   }
 }
 
 export function toJsonCourseDetail(
   course: ECourse.Extended,
-  lecture: subject_lecture,
+  lecture: subject_lecture | undefined,
   professor: subject_professor[],
 ): ICourse.Detail {
   const basic = toJsonCourseBasic(course, lecture)


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'credit')` reported by Sentry.

- `toJsonCourseBasic` / `toJsonCourseDetail` now accept a possibly missing representative lecture and fall back to the zero values the fields already declared
- removes a leftover debug log that dumped full course rows into production logs

## Root cause

`CoursesService.getCourseById` and `PlannersService` create the serializer argument from an array index:

```ts
const representativeLecture = (await this.lectureRepository.getLecturesByIds([course.representative_lecture_id]))[0]
```

When a course has no resolvable representative lecture, that value is `undefined`, so `lecture.credit` threw and the request returned 500. The list endpoint already guards this case with `if (!representativeLecture) continue`, but the single-course and planner paths did not.

## Sentry impact

| Issue | Events | Users | Entry point |
| --- | --- | --- | --- |
| `OTL-SERVER-NEST-PROD-5W` | 692 | 136 | `GET /api/courses/:id` |
| `OTL-SERVER-NEST-PROD-2Y` | 760 | 16 | `POST /api/users/:id/planners/:id/update-item` |

## Validation

- New unit spec reproduces the exact Sentry error before the fix and passes after it
- `npx jest apps/server/src/common/serializer/course.serializer.spec.ts` — 2 passed
- `tsc --noEmit` reports the same 74 pre-existing errors as `origin/main`, none in the changed files
- `eslint` clean on the changed source file
