### PR TITLE
fix: validate custom block time updates

### DIFF
--- a/apps/server/src/common/interfaces/ICustomblock.ts
+++ b/apps/server/src/common/interfaces/ICustomblock.ts
@@ -19,13 +19,14 @@ export namespace ICustomblock {
     @Type(() => String)
     block_name!: string
 
-    @IsNotEmpty()
     @IsString()
     @Type(() => String)
     place!: string
 
     @IsNotEmpty()
     @IsInt()
+    @Min(0)
+    @Max(6)
     day!: number
 
     @IsNotEmpty()
@@ -36,8 +37,8 @@ export namespace ICustomblock {
 
     @IsNotEmpty()
     @IsInt()
-    @Min(0) // 00:00 = 0분
-    @Max(1439) // 23:59 = 1439분
+    @Min(1)
+    @Max(1440) // 24:00 = 1440분
     end!: number
   }
 
@@ -51,7 +52,6 @@ export namespace ICustomblock {
   }
 
   export class UpdateDto {
-    // PATCH: place, block_name만 수정 가능 (둘 다 optional)
     @IsOptional()
     @IsString()
     @Type(() => String)
@@ -61,6 +61,27 @@ export namespace ICustomblock {
     @IsString()
     @Type(() => String)
     place?: string
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(6)
+    @Type(() => Number)
+    day?: number
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(1439)
+    @Type(() => Number)
+    begin?: number
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(1440)
+    @Type(() => Number)
+    end?: number
   }
 
   export class DeleteDto {

--- a/apps/server/src/modules/timetables/timetables.controller.ts
+++ b/apps/server/src/modules/timetables/timetables.controller.ts
@@ -101,7 +101,7 @@ export class TimetablesController {
     return { id: created.id }
   }
 
-  // 특정 custom block 수정하기 (place, block_name)
+  // 특정 custom block 수정하기
   @Patch('/:timetableId/custom-blocks/:customblockId')
   async updateCustomblock(
     @Param('timetableId') timetableId: number,

--- a/apps/server/src/modules/timetables/timetables.service.ts
+++ b/apps/server/src/modules/timetables/timetables.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   HttpException,
   HttpStatus,
@@ -19,6 +20,7 @@ import {
   CustomblockRepository, LectureRepository, SemesterRepository, TimetableRepository,
 } from '@otl/prisma-client'
 import { orderFilter } from '@otl/prisma-client/common/util'
+import { ECustomblock } from '@otl/prisma-client/entities/ECustomblock'
 import { ELecture } from '@otl/prisma-client/entities/ELecture'
 import { ETimetable } from '@otl/prisma-client/entities/ETimetable'
 
@@ -142,10 +144,36 @@ export class TimetablesService {
     return timetable
   }
 
+  private async validateCustomblockTime(
+    timetableId: number,
+    candidate: ECustomblock.Time,
+    customblocks: ECustomblock.Basic[],
+  ) {
+    if (candidate.begin >= candidate.end) {
+      throw new BadRequestException('Custom block end must be later than begin')
+    }
+
+    const timetableLectures = await this.timetableRepository.getLecturesWithClassTimes(timetableId)
+    const lectureTimes = timetableLectures
+      .flatMap(({ subject_lecture }) => subject_lecture.subject_classtime)
+      .map(({ day, begin, end }) => ({
+        day,
+        begin: begin.getUTCHours() * 60 + begin.getUTCMinutes(),
+        end: end.getUTCHours() * 60 + end.getUTCMinutes(),
+      }))
+    const timetableEntries = [...customblocks, ...lectureTimes]
+
+    if (timetableEntries.some((time) => ECustomblock.overlaps(candidate, time))) {
+      throw new ConflictException('Custom block overlaps an existing timetable entry')
+    }
+  }
+
   // 커스텀 블록 관련 Service 로직
   @Transactional()
   async addCustomblockToTimetable(timetableId: number, body: ICustomblock.CreateDto, user: session_userprofile) {
     await this.TimetableValidation(user, timetableId)
+    const customblocks = await this.customblockRepository.getCustomblocksList(timetableId)
+    await this.validateCustomblockTime(timetableId, body, customblocks)
     const customBlock = await this.customblockRepository.createCustomblock({
       block_name: body.block_name,
       place: body.place,
@@ -172,6 +200,16 @@ export class TimetablesService {
     user: session_userprofile,
   ) {
     await this.TimetableValidation(user, timetableId)
+    const customblocks = await this.customblockRepository.getCustomblocksList(timetableId)
+    const current = customblocks.find((customblock) => customblock.id === customblockId)
+    if (!current) {
+      throw new NotFoundException('No such custom block in timetable')
+    }
+    await this.validateCustomblockTime(
+      timetableId,
+      { ...current, ...body },
+      customblocks.filter((customblock) => customblock.id !== customblockId),
+    )
     return this.customblockRepository.updateCustomblock(customblockId, body)
   }
 

--- a/apps/server/src/modules/timetables/v2/timetables.controller.ts
+++ b/apps/server/src/modules/timetables/v2/timetables.controller.ts
@@ -98,7 +98,7 @@ export class TimetablesControllerV2 {
     return { id: created.id }
   }
 
-  // 특정 custom block 수정하기 (place, block_name)
+  // 특정 custom block 수정하기
   @Patch('/:timetableId/custom-blocks/:customblockId')
   async updateCustomblock(
     @Param('timetableId') timetableId: number,

--- a/apps/server/src/modules/timetables/v2/timetables.service.ts
+++ b/apps/server/src/modules/timetables/v2/timetables.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Inject,
   Injectable,
@@ -21,6 +22,7 @@ import { Prisma, session_userprofile } from '@prisma/client'
 import logger from '@otl/common/logger/logger'
 
 import { CustomblockRepository, LectureRepository, TimetableRepository } from '@otl/prisma-client'
+import { ECustomblock } from '@otl/prisma-client/entities/ECustomblock'
 
 @Injectable()
 export class TimetablesServiceV2 {
@@ -383,9 +385,35 @@ export class TimetablesServiceV2 {
     return timetable
   }
 
+  private async validateCustomblockTime(
+    timetableId: number,
+    candidate: ECustomblock.Time,
+    customblocks: ECustomblock.Basic[],
+  ) {
+    if (candidate.begin >= candidate.end) {
+      throw new BadRequestException('Custom block end must be later than begin')
+    }
+
+    const timetableLectures = await this.timetableRepository.getLecturesWithClassTimes(timetableId)
+    const lectureTimes = timetableLectures
+      .flatMap(({ subject_lecture }) => subject_lecture.subject_classtime)
+      .map(({ day, begin, end }) => ({
+        day,
+        begin: begin.getUTCHours() * 60 + begin.getUTCMinutes(),
+        end: end.getUTCHours() * 60 + end.getUTCMinutes(),
+      }))
+    const timetableEntries = [...customblocks, ...lectureTimes]
+
+    if (timetableEntries.some((time) => ECustomblock.overlaps(candidate, time))) {
+      throw new ConflictException('Custom block overlaps an existing timetable entry')
+    }
+  }
+
   @Transactional()
   async addCustomblockToTimetable(timetableId: number, body: ICustomblock.CreateDto, user: session_userprofile) {
     await this.TimetableValidation(user, timetableId)
+    const customblocks = await this.customblockRepository.getCustomblocksList(timetableId)
+    await this.validateCustomblockTime(timetableId, body, customblocks)
     const customBlock = await this.customblockRepository.createCustomblock({
       block_name: body.block_name,
       place: body.place,
@@ -412,6 +440,16 @@ export class TimetablesServiceV2 {
     user: session_userprofile,
   ) {
     await this.TimetableValidation(user, timetableId)
+    const customblocks = await this.customblockRepository.getCustomblocksList(timetableId)
+    const current = customblocks.find((customblock) => customblock.id === customblockId)
+    if (!current) {
+      throw new NotFoundException('No such custom block in timetable')
+    }
+    await this.validateCustomblockTime(
+      timetableId,
+      { ...current, ...body },
+      customblocks.filter((customblock) => customblock.id !== customblockId),
+    )
     return this.customblockRepository.updateCustomblock(customblockId, body)
   }
 

--- a/libs/prisma-client/src/entities/ECustomblock.spec.ts
+++ b/libs/prisma-client/src/entities/ECustomblock.spec.ts
@@ -1,0 +1,11 @@
+import { ECustomblock } from './ECustomblock'
+
+describe('ECustomblock.overlaps', () => {
+  it.each([
+    [{ day: 0, begin: 600, end: 660 }, { day: 0, begin: 630, end: 690 }, true],
+    [{ day: 0, begin: 600, end: 660 }, { day: 0, begin: 660, end: 720 }, false],
+    [{ day: 0, begin: 600, end: 660 }, { day: 1, begin: 600, end: 660 }, false],
+  ])('compares half-open timetable ranges', (left, right, expected) => {
+    expect(ECustomblock.overlaps(left, right)).toBe(expected)
+  })
+})

--- a/libs/prisma-client/src/entities/ECustomblock.ts
+++ b/libs/prisma-client/src/entities/ECustomblock.ts
@@ -11,5 +11,8 @@ export namespace ECustomblock {
 
   // Helper input shapes for service/repo methods (pair with ICustomblock DTOs)
   export type CreateInput = Pick<Basic, 'block_name' | 'place' | 'day' | 'begin' | 'end'>
-  export type UpdateInput = Partial<Pick<Basic, 'block_name' | 'place'>>
+  export type UpdateInput = Partial<CreateInput>
+  export type Time = Pick<Basic, 'day' | 'begin' | 'end'>
+
+  export const overlaps = (left: Time, right: Time) => left.day === right.day && left.begin < right.end && right.begin < left.end
 }

--- a/libs/prisma-client/src/repositories/customblock.repository.ts
+++ b/libs/prisma-client/src/repositories/customblock.repository.ts
@@ -56,11 +56,8 @@ export class CustomblockRepository {
     })
   }
 
-  // block_name과 string만 업데이트
-  async updateCustomblock(
-    customblockId: number,
-    updateData: { block_name?: string, place?: string },
-  ): Promise<ECustomblock.Basic> {
+  // 커스텀 블록 업데이트
+  async updateCustomblock(customblockId: number, updateData: ECustomblock.UpdateInput): Promise<ECustomblock.Basic> {
     return this.prisma.block_custom_blocks.update({
       where: { id: customblockId },
       data: updateData,


### PR DESCRIPTION
## Summary

- allow custom block PATCH requests to update day, begin, and end
- reject invalid or overlapping custom block times against both custom blocks and lecture class times
- verify the custom block belongs to the requested timetable before updating it
- apply the same behavior to legacy and v2 timetable APIs

## Verification

- `yarn eslint <changed files>`
- `yarn jest libs/prisma-client/src/entities/ECustomblock.spec.ts --runInBand`
- `yarn build:server`
- live local frontend/backend integration: create 201, time update 200, overlap 409, adjacent range 201, delete 200

Frontend: https://github.com/sparcs-kaist/otlplus-web-v4/pull/132